### PR TITLE
Added .vba and .bas

### DIFF
--- a/VBScript.tmLanguage
+++ b/VBScript.tmLanguage
@@ -7,6 +7,8 @@
 	<key>fileTypes</key>
 	<array>
 		<string>vbs</string>
+		<string>vba</string>
+		<string>bas</string>
 		<string>vbe</string>
 		<string>wsf</string>
 		<string>wsc</string>


### PR DESCRIPTION
Even though everything in VBA is not supported in this syntax highlighter, it get's most of it right.

.BAS is a common VBS, VBA file extension. Unless they are a QBasic or X11 dev there shouldn't be any conflicts.